### PR TITLE
pinning bahmutov/npm-install to 1.10.9 with hash

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
           node-version: ${{ matrix.node }}
 
       - name: Install deps and build (with cache)
-        uses: bahmutov/npm-install@v1
+        uses: bahmutov/npm-install@6bbff949458c1dd99b20e185cee8c4d6fcf1212a # v1.10.9
 
       - name: Lint
         run: yarn run lint


### PR DESCRIPTION
Pinning `bahmutov/npm-install` by hash instead of tag to satisfy zizmor